### PR TITLE
Change deleteAccount endpoint to send 204 upon successful deletion

### DIFF
--- a/server/controllers/user.go
+++ b/server/controllers/user.go
@@ -105,7 +105,7 @@ func DeleteUserAccount(c *gin.Context) {
 		return
 	}
 
-	c.Status(http.StatusOK)
+	c.Status(http.StatusNoContent)
 }
 
 // POST /api/v1/users/reset-password-email


### PR DESCRIPTION
This is to follow HTTP delete request conventions as specified in the MDN Web Docs.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE